### PR TITLE
Add Code of Conduct page

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -16,6 +16,7 @@ const menuItems = [
   { link: '/program', text: 'Program' },
   { link: '/speakers', text: 'Speakers' },
   { link: '/committee', text: 'Committee' },
+  { link: '/coc', text: 'Code of Conduct' },
   { link: '/sponsors', text: 'Sponsors' }
 ];
 

--- a/src/pages/coc.css
+++ b/src/pages/coc.css
@@ -1,0 +1,3 @@
+.codeOfConduct__reporting {
+  margin-top: 2em;
+}

--- a/src/pages/coc.js
+++ b/src/pages/coc.js
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import './coc.css';
+
+const CodeOfConduct = () => (
+  <div>
+    <h1>Code of Conduct</h1>
+    <p>All attendees, speakers, sponsors, and volunteers at the WAC are required to agree with the following code of conduct. The WAC code of conduct is based on the <a href="http://berlincodeofconduct.org">Berlin Code of Conduct</a>.</p>
+
+    <h3>Purpose</h3>
+    <p>A primary goal of all the conferences and user groups that refer to this Code of Conduct is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status and religion (or lack thereof).</p>
+    <p>This Code of Conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.</p>
+    <p>We invite all those who participate in our events to help us create safe and positive experiences for everyone.</p>
+
+    <h3>Open [Source/Culture/Tech] Citizenship</h3>
+    <p>A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.</p>
+    <p>Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.</p>
+    <p>If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.</p>
+
+    <h3>Expected Behavior</h3>
+    <ul>
+      <li>Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.</li>
+      <li>Exercise consideration and respect in your speech and actions.</li>
+      <li>Attempt collaboration before conflict.</li>
+      <li>Refrain from demeaning, discriminatory, or harassing behavior and speech.</li>
+      <li>Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.</li>
+    </ul>
+
+    <h3>Unacceptable Behavior</h3>
+    <p>Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning speech or actions by any participant in our community online, at all related events and in one-on-one communications carried out in the context of community business. Community event venues may be shared with members of the public; please be respectful to all patrons of these locations.</p>
+    <p>Harassment includes: harmful or prejudicial verbal or written comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images (including presentation slides); inappropriate depictions of violence (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.</p>
+
+    <h3>Consequences of Unacceptable Behavior</h3>
+    <p>Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated. Anyone asked to stop unacceptable behavior is expected to comply immediately.</p>
+    <p>If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).</p>
+
+    <h3>If You Witness or Are Subject to Unacceptable Behavior</h3>
+    <p>If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. You can find a list of organizers to contact for each of the supporters of this code of conduct at the bottom of this page. Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.</p>
+
+    <h3>Addressing Grievances</h3>
+    <p>If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify one of the event organizers with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies.</p>
+
+    <h3>Scope</h3>
+    <p>We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues—online and in-person—as well as in all one-on-one communications pertaining to community business.</p>
+
+    <h3>License and attribution</h3>
+    <p>Berlin Code of Conduct is distributed under a Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license. It is based on the pdx.rb code of conduct.</p>
+
+    <h2 className="codeOfConduct__reporting">Reporting Violations</h2>
+    <h4>Anonymous Report</h4>
+    <p>You can make an anonymous report <a href="TODO">here</a>. We can’t follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.</p>
+    <h4>Personal Report</h4>
+    <p>You can make a personal report by:</p>
+    <ul>
+      <li>Emailing us at: <a href="mailto:chairs@webaudioconf.com">chairs@webaudioconf.com</a></li>
+      <li>Calling us at: +49 157 789 021 18</li>
+    </ul>
+  </div>
+)
+
+export default CodeOfConduct;

--- a/src/pages/coc.js
+++ b/src/pages/coc.js
@@ -48,7 +48,7 @@ const CodeOfConduct = () => (
 
     <h2 className="codeOfConduct__reporting">Reporting Violations</h2>
     <h4>Anonymous Report</h4>
-    <p>You can make an anonymous report <a href="TODO">here</a>. We can’t follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.</p>
+    <p>We will post a form here for submitting anonymous reports prior to the conference. We can’t follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.</p>
     <h4>Personal Report</h4>
     <p>You can make a personal report by:</p>
     <ul>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -40,6 +40,13 @@ const IndexPage = () => (
       </p>
     </div>
 
+    <div className="index__codeOfConduct">
+      <h4>Code of Conduct</h4>
+      <p className="index__text">
+        <p>All attendees, speakers, sponsors, and volunteers at the WAC are required to agree with the following code of conduct: <Link to="/coc">Read the Code of Conduct</Link>.</p>
+      </p>
+    </div>
+
     <div className="index__newsletter">
       <div className="six columns">
         <form action="https://webaudioconf.us17.list-manage.com/subscribe/post?u=786ac969cb6e9a620eda77728&amp;id=84c4ce8f63" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank" noValidate>


### PR DESCRIPTION
This commit adds the Berlin code of conduct to the web audio conference page.

Simply linking to a code of conduct is not considered best practice, for the reasons outlined by
Frederic in PR #27.

In this commit we add a code of conduct page which is accessible via the homepage/index of the site, as well as through the navigation header. Most importantly, the CoC provides information on how to report violations at this specific event.

If we want to allow attendees to anonymously report violations (like JSConf EU does https://2018.jsconf.eu/code-of-conduct/), we should create a google form that will allow this and link to it.

Also, another outstanding issue is whether you're OK having your personal phone number on this website @janmonschke. 